### PR TITLE
Mark node modules as external

### DIFF
--- a/bin/esbuild-node.js
+++ b/bin/esbuild-node.js
@@ -26,16 +26,21 @@ if (!fs.existsSync("./" + script)) {
 var buildSync = require("esbuild").buildSync;
 
 // Find all node modules to mark as external
-var findNodeModules = require('find-node-modules');
-var sources = findNodeModules();
+var path = require('path');
 var external = [];
-sources.forEach(function (dir) {
-    var packages = fs.readdirSync(dir);
-    packages.forEach(function (package) {
-        if (package.charAt(0) !== '.')
-            external.push(package);
-    });
-});
+function findNodeModules(dir) {
+    var moduleDir = path.join(dir, 'node_modules');
+    if (fs.existsSync(moduleDir)) {
+        var packages = fs.readdirSync(moduleDir);
+        packages.forEach(function (package) {
+            if (package.charAt(0) !== '.')
+                external.push(package);
+        });
+    }
+    var parent = path.dirname(dir);
+    if (parent !== dir && fs.existsSync(parent)) findNodeModules(parent);
+}
+findNodeModules(process.cwd());
 
 var res = buildSync({
     entryPoints: ["./" + script],

--- a/bin/esbuild-node.js
+++ b/bin/esbuild-node.js
@@ -25,12 +25,25 @@ if (!fs.existsSync("./" + script)) {
 // Build
 var buildSync = require("esbuild").buildSync;
 
+// Find all node modules to mark as external
+var findNodeModules = require('find-node-modules');
+var sources = findNodeModules();
+var external = [];
+sources.forEach(function (dir) {
+    var packages = fs.readdirSync(dir);
+    packages.forEach(function (package) {
+        if (package.charAt(0) !== '.')
+            external.push(package);
+    });
+});
+
 var res = buildSync({
     entryPoints: ["./" + script],
     write: false,
     platform: "node",
     bundle: true,
     target: "es2015",
+    external: external
 });
 
 eval(Buffer.from(res.outputFiles[0].contents).toString());

--- a/package.json
+++ b/package.json
@@ -28,8 +28,5 @@
     "devDependencies": {
         "esbuild": "0.6.16",
         "release-it": "13.6.4"
-    },
-    "dependencies": {
-        "find-node-modules": "^2.1.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
     "devDependencies": {
         "esbuild": "0.6.16",
         "release-it": "13.6.4"
+    },
+    "dependencies": {
+        "find-node-modules": "^2.1.0"
     }
 }


### PR DESCRIPTION
Bundling node modules is not really required for execution with node. In some cases (using a lib with bindings) bundling would fail too.