### PR TITLE
Run in vm context

### DIFF
--- a/bin/esbuild-node.js
+++ b/bin/esbuild-node.js
@@ -51,4 +51,21 @@ var res = buildSync({
     external: external
 });
 
-eval(Buffer.from(res.outputFiles[0].contents).toString());
+var Module = require('module');
+var dir = path.dirname(script);
+var scriptModule = new Module(dir);
+scriptModule.filename = script;
+scriptModule.paths = Module._nodeModulePaths(dir);
+
+Object.assign(global, {
+    __filename: script,
+    __dirname: dir,
+    exports: scriptModule.exports,
+    module: scriptModule,
+    require: scriptModule.require.bind(scriptModule)
+});
+
+require('vm').runInThisContext(
+    Buffer.from(res.outputFiles[0].contents).toString(),
+    {filename: script}
+);


### PR DESCRIPTION
This improves execution by making sure module features (eg __filename, require etc) are scoped to where the script is located. Stack trace also includes the script name. Basically executes scripts the same way as ts-node.